### PR TITLE
Add interspersion support to (sub-)commands so it's possible to disable

### DIFF
--- a/app.go
+++ b/app.go
@@ -290,7 +290,7 @@ func (a *Application) Command(name, help string) *CmdClause {
 	return a.addCommand(name, help)
 }
 
-// Interspersed control if flags can be interspersed with positional arguments
+// Interspersed controls if flags can be interspersed with positional arguments
 //
 // true (the default) means that they can, false means that all the flags must appear before the first positional arguments.
 func (a *Application) Interspersed(interspersed bool) *Application {

--- a/cmd.go
+++ b/cmd.go
@@ -202,6 +202,9 @@ type CmdClause struct {
 	validator      CmdClauseValidator
 	hidden         bool
 	completionAlts []string
+	// noInterspersed specifies whether this command allows flags to be interspersed with positional argumentss.
+	// Overrides the application setting.
+	noInterspersed bool
 }
 
 func newCommand(app *Application, name, help string) *CmdClause {
@@ -282,5 +285,14 @@ func (c *CmdClause) init() error {
 
 func (c *CmdClause) Hidden() *CmdClause {
 	c.hidden = true
+	return c
+}
+
+// Interspersed controls if flags can be interspersed with positional arguments.
+//
+// true (the default) means that they can, false means that all the flags must appear
+// before the first positional arguments.
+func (c *CmdClause) Interspersed(interspersed bool) *CmdClause {
+	c.noInterspersed = !interspersed
 	return c
 }

--- a/cmd_test.go
+++ b/cmd_test.go
@@ -372,3 +372,40 @@ func TestDefaultCmdCompletion(t *testing.T) {
 	// With both args of a default sub cmd, should get no completions
 	assert.Empty(t, complete(t, app, "arg1", "arg2"))
 }
+
+func TestCommandInterspersedFalse(t *testing.T) {
+	app := newTestApp().Interspersed(false)
+	cmd := app.Command("run", "Run an arbitrary command").Interspersed(false)
+	a1 := cmd.Arg("a1", "").String()
+	a2 := cmd.Arg("a2", "").String()
+	f1 := cmd.Flag("flag", "").String()
+
+	_, err := app.Parse([]string{"run", "a1", "--flag=flag"})
+	assert.NoError(t, err)
+	assert.Equal(t, "a1", *a1)
+	assert.Equal(t, "--flag=flag", *a2)
+	assert.Equal(t, "", *f1)
+}
+
+func TestCommandInterspersedTrue(t *testing.T) {
+	// test once with the default value and once with explicit true
+	for i := 0; i < 2; i++ {
+		app := newTestApp()
+		cmd := app.Command("run", "Run arbitrary command")
+		if i != 0 {
+			t.Log("Setting explicit")
+			cmd.Interspersed(true)
+		} else {
+			t.Log("Using default")
+		}
+		a1 := cmd.Arg("a1", "").String()
+		a2 := cmd.Arg("a2", "").String()
+		f1 := cmd.Flag("flag", "").String()
+
+		_, err := app.Parse([]string{"run", "a1", "--flag=flag"})
+		assert.NoError(t, err)
+		assert.Equal(t, "a1", *a1)
+		assert.Equal(t, "", *a2)
+		assert.Equal(t, "flag", *f1)
+	}
+}


### PR DESCRIPTION
This PR adds interspersion support to (sub-)commands so it's possible to disable on command level as opposed to only on application level.
This will allow to implement commands that accept arbitrary arguments to pass to another (possibly external) command (i.e. `gravity exec`).