### PR TITLE
Allow Duplicates

### DIFF
--- a/app.go
+++ b/app.go
@@ -305,6 +305,9 @@ func checkDuplicateFlags(current *CmdClause, flagGroups []*flagGroup) error {
 	// Check for duplicates.
 	for _, flags := range flagGroups {
 		for _, flag := range current.flagOrder {
+			if flag.allowDuplicate {
+				continue
+			}
 			if flag.shorthand != 0 {
 				if _, ok := flags.short[string(flag.shorthand)]; ok {
 					return fmt.Errorf("duplicate short flag -%c", flag.shorthand)

--- a/flags.go
+++ b/flags.go
@@ -64,6 +64,9 @@ func (f *flagGroup) checkDuplicates() error {
 	seenShort := map[byte]bool{}
 	seenLong := map[string]bool{}
 	for _, flag := range f.flagOrder {
+		if flag.allowDuplicate {
+			continue
+		}
 		if flag.shorthand != 0 {
 			if _, ok := seenShort[flag.shorthand]; ok {
 				return fmt.Errorf("duplicate short flag -%c", flag.shorthand)
@@ -167,6 +170,9 @@ type FlagClause struct {
 	defaultValues []string
 	placeholder   string
 	hidden        bool
+
+	// allowDuplicate allows this flag to be repeated.
+	allowDuplicate bool
 }
 
 func newFlag(name, help string) *FlagClause {
@@ -225,6 +231,12 @@ func (f *FlagClause) init() error {
 		return fmt.Errorf("invalid default for '--%s', expecting single value", f.name)
 	}
 	return nil
+}
+
+// AllowDuplicate allows this flag to be repeated.
+func (f *FlagClause) AllowDuplicate() *FlagClause {
+	f.allowDuplicate = true
+	return f
 }
 
 // Dispatch to the given function after the flag is parsed and validated.


### PR DESCRIPTION
**Purpose**

Allow duplicate flags. Useful when wanting to print useful error messages telling the user the correct position of the flag.

**Implementation**

Added `AllowDuplicate` to `FlagClause`. When this is attached to a flag, it will be skipped over when checking for duplicates.