### PR TITLE
Report all missing flags.

### DIFF
--- a/app.go
+++ b/app.go
@@ -420,7 +420,7 @@ func (a *Application) validateRequired(context *ParseContext) error {
 	// Check required flags and set defaults.
 	var missingFlags []*FlagClause
 
-	for _, flag := range context.flags.long {
+	for _, flag := range context.flags.flagOrder {
 		if flagElements[flag.name] == nil {
 			// Check required flags were provided.
 			if flag.needsValue() {

--- a/app.go
+++ b/app.go
@@ -418,13 +418,36 @@ func (a *Application) validateRequired(context *ParseContext) error {
 	}
 
 	// Check required flags and set defaults.
+	var missingFlags []*FlagClause
+
 	for _, flag := range context.flags.long {
 		if flagElements[flag.name] == nil {
 			// Check required flags were provided.
 			if flag.needsValue() {
-				return fmt.Errorf("required flag --%s not provided", flag.name)
+				missingFlags = append(missingFlags, flag)
 			}
 		}
+	}
+
+	if len(missingFlags) > 0 {
+		fmtFlag := func(flag *FlagClause) string {
+			if flag.shorthand != 0 {
+				return fmt.Sprintf("--%s/-%c", flag.name, flag.shorthand)
+			} else {
+				return fmt.Sprintf("--%s", flag.name)
+			}
+		}
+
+		if len(missingFlags) == 1 {
+			flag := missingFlags[0]
+			return fmt.Errorf("required flag %v not provided", fmtFlag(flag))
+		}
+
+		var flags []string
+		for _, flag := range missingFlags {
+			flags = append(flags, fmtFlag(flag))
+		}
+		return fmt.Errorf("required flags %v not provided", flags)
 	}
 
 	for _, arg := range context.arguments.args {

--- a/app_test.go
+++ b/app_test.go
@@ -36,8 +36,24 @@ func TestRequiredFlags(t *testing.T) {
 
 	_, err := c.Parse([]string{"--a=foo"})
 	assert.Error(t, err)
+	assert.Equal(t, "required flag --b not provided", err.Error())
 	_, err = c.Parse([]string{"--b=foo"})
 	assert.NoError(t, err)
+}
+
+func TestRequiredFlagsErrors(t *testing.T) {
+	c := newTestApp()
+	c.Flag("c", "c").Required().String()
+	c.Flag("b", "b").Required().String()
+	c.Flag("a", "a").Required().String()
+
+	_, err := c.Parse([]string{"--a=foo", "--b=foo", "--c=foo"})
+	assert.NoError(t, err)
+
+	// ensure the flag order is preserved and all missing flags are reported.
+	_, err = c.Parse([]string{})
+	assert.Error(t, err)
+	assert.Equal(t, "required flags [--c --b --a] not provided", err.Error())
 }
 
 func TestRepeatableFlags(t *testing.T) {

--- a/app_test.go
+++ b/app_test.go
@@ -56,6 +56,21 @@ func TestRequiredFlagsErrors(t *testing.T) {
 	assert.Equal(t, "required flags [--c --b --a] not provided", err.Error())
 }
 
+func TestRequiredShorthandFlagsErrors(t *testing.T) {
+	c := newTestApp()
+	c.Flag("foo", "c").Short('c').Required().String()
+	c.Flag("bar", "b").Short('b').Required().String()
+	c.Flag("baz", "a").Short('a').Required().String()
+
+	_, err := c.Parse([]string{"--foo=foo", "--bar=foo", "--baz=foo"})
+	assert.NoError(t, err)
+
+	// ensure the flag order is preserved and all missing flags are reported.
+	_, err = c.Parse([]string{})
+	assert.Error(t, err)
+	assert.Equal(t, "required flags [--foo/-c --bar/-b --baz/-a] not provided", err.Error())
+}
+
 func TestRepeatableFlags(t *testing.T) {
 	c := newTestApp()
 	c.Flag("a", "a").String()


### PR DESCRIPTION
Currently, the missing `.Required()` flags are processed in random order, with the first one missing being reported. 

In a real example I encountered during development, the program will randomly report either of:
- `ERROR: required flag --secret not provided`
- `ERROR: required flag --claims-to-roles not provided`

This PR changes the error reporting in the following ways:
- all missing required flags are reported
- the flags are processed in deterministic order, as declared and seen in `--help`
- multiple missing flags are reported as `required flags [--foo --bar --baz] not provided`
- single missing flag is reported as `required flag --foo not provided` *(no change)*
- shorthand flags are shown: `required flags [--foo/-a --bar/-b --baz/-c] not provided` `required flag --foo/-a not provided`

Given the changes above, the motivating example becomes:
- `ERROR: required flags [--claims-to-roles/-r --secret] not provided`