### PR TITLE
Allow all flags to be repeated (false by default).

### DIFF
--- a/app.go
+++ b/app.go
@@ -106,6 +106,7 @@ func (a *Application) Terminate(terminate func(int)) *Application {
 }
 
 // AllRepeatable specifies if all flags should be treated as repeatable. Default is false, true is UNIX convention.
+// UNIX convention means that all flags can be repeated, but the last value of flag is used.
 func (a *Application) AllRepeatable(repeatable bool) *Application {
 	a.allRepeatable = repeatable
 	return a

--- a/app.go
+++ b/app.go
@@ -36,6 +36,7 @@ type Application struct {
 	usageTemplate  string
 	validator      ApplicationValidator
 	terminate      func(status int) // See Terminate()
+	allRepeatable  bool             // can all flags be repeated? default false, UNIX convention is true.
 	noInterspersed bool             // can flags be interspersed with args (or must they come first)
 	defaultEnvars  bool
 
@@ -101,6 +102,12 @@ func (a *Application) Terminate(terminate func(int)) *Application {
 		terminate = func(int) {}
 	}
 	a.terminate = terminate
+	return a
+}
+
+// AllRepeatable specifies if all flags should be treated as repeatable. Default is false, true is UNIX convention.
+func (a *Application) AllRepeatable(repeatable bool) *Application {
+	a.allRepeatable = repeatable
 	return a
 }
 
@@ -469,9 +476,11 @@ func (a *Application) setValues(context *ParseContext) (selected []string, err e
 	for _, element := range context.Elements {
 		switch clause := element.Clause.(type) {
 		case *FlagClause:
-			if _, ok := flagSet[clause.name]; ok {
-				if v, ok := clause.value.(repeatableFlag); !ok || !v.IsCumulative() {
-					return nil, fmt.Errorf("flag '%s' cannot be repeated", clause.name)
+			if !a.allRepeatable {
+				if _, ok := flagSet[clause.name]; ok {
+					if v, ok := clause.value.(repeatableFlag); !ok || !v.IsCumulative() {
+						return nil, fmt.Errorf("flag '%s' cannot be repeated", clause.name)
+					}
 				}
 			}
 			if err = clause.value.Set(*element.Value); err != nil {

--- a/app_test.go
+++ b/app_test.go
@@ -72,7 +72,7 @@ func TestRequiredShorthandFlagsErrors(t *testing.T) {
 
 func TestRepeatableFlags(t *testing.T) {
 	c := newTestApp()
-	c.Flag("a", "a").String()
+	aflag := c.Flag("a", "a").String()
 	c.Flag("b", "b").Strings()
 	_, err := c.Parse([]string{"--a=foo", "--a=bar"})
 	assert.Error(t, err)
@@ -82,6 +82,7 @@ func TestRepeatableFlags(t *testing.T) {
 	c.AllRepeatable(true)
 	_, err = c.Parse([]string{"--a=foo", "--a=bar"})
 	assert.NoError(t, err)
+	assert.Equal(t, *aflag, "bar")
 	_, err = c.Parse([]string{"--b=foo", "--b=bar"})
 	assert.NoError(t, err)
 }

--- a/app_test.go
+++ b/app_test.go
@@ -2,11 +2,10 @@ package kingpin
 
 import (
 	"io/ioutil"
-
-	"github.com/alecthomas/assert"
-
 	"testing"
 	"time"
+
+	"github.com/alecthomas/assert"
 )
 
 func newTestApp() *Application {
@@ -77,6 +76,12 @@ func TestRepeatableFlags(t *testing.T) {
 	c.Flag("b", "b").Strings()
 	_, err := c.Parse([]string{"--a=foo", "--a=bar"})
 	assert.Error(t, err)
+	_, err = c.Parse([]string{"--b=foo", "--b=bar"})
+	assert.NoError(t, err)
+
+	c.AllRepeatable(true)
+	_, err = c.Parse([]string{"--a=foo", "--a=bar"})
+	assert.NoError(t, err)
 	_, err = c.Parse([]string{"--b=foo", "--b=bar"})
 	assert.NoError(t, err)
 }


### PR DESCRIPTION
This makes the Kingpin compatible with the UNIX convention and makes it much easier to compose commands and build command aliases.

Before change:
```
➜  ~ tsh --debug --debug login
...
ERROR: flag 'debug' cannot be repeated
```

After this change (and enabling this option via `Application.AllRepeatable(true)`) the above works without problems.