### PR TITLE
Define ErrExpectedCommand and use it.

### DIFF
--- a/app.go
+++ b/app.go
@@ -1,6 +1,7 @@
 package kingpin
 
 import (
+	"errors"
 	"fmt"
 	"io"
 	"os"
@@ -9,7 +10,7 @@ import (
 )
 
 var (
-	ErrCommandNotSpecified = fmt.Errorf("command not specified")
+	ErrCommandNotSpecified = errors.New("command not specified")
 )
 
 var (

--- a/parser.go
+++ b/parser.go
@@ -38,6 +38,10 @@ var (
 	TokenEOLMarker = Token{-1, TokenEOL, ""}
 )
 
+var (
+	ErrExpectedCommand = fmt.Errorf("expected command")
+)
+
 type Token struct {
 	Index int
 	Type  TokenType
@@ -316,7 +320,7 @@ loop:
 						}
 					}
 					if cmd == nil {
-						return fmt.Errorf("expected command but got %q", token)
+						return fmt.Errorf("%w but got %q", ErrExpectedCommand, token)
 					}
 				}
 				if cmd == HelpCommand {

--- a/parser.go
+++ b/parser.go
@@ -2,6 +2,7 @@ package kingpin
 
 import (
 	"bufio"
+	"errors"
 	"fmt"
 	"os"
 	"strings"
@@ -39,7 +40,7 @@ var (
 )
 
 var (
-	ErrExpectedCommand = fmt.Errorf("expected command")
+	ErrExpectedCommand = errors.New("expected command")
 )
 
 type Token struct {


### PR DESCRIPTION
Defines new error `ErrExpectedCommand`. This can be subsequently checked, e.g.:

```go
if errors.Is(err, kingpin.ErrExpectedCommand) {
   // ...
}
```