### PR TITLE
Update with upstream: part 4

### DIFF
--- a/README.md
+++ b/README.md
@@ -621,6 +621,22 @@ You can see an in depth example of the completion API within
 
 `kingpin.CommandLine.HelpFlag.Short('h')`
 
+Short help is also available when creating a more complicated app:
+
+```go
+var (
+	app = kingpin.New("chat", "A command-line chat application.")
+  // ...
+)
+
+func main() {
+	app.HelpFlag.Short('h')
+	switch kingpin.MustParse(app.Parse(os.Args[1:])) {
+  // ...
+  }
+}
+```
+
 ### Custom help
 
 Kingpin v2 supports templatised help using the text/template library (actually, [a fork](https://github.com/alecthomas/template)).

--- a/_examples/chat1/main.go
+++ b/_examples/chat1/main.go
@@ -8,7 +8,7 @@ import (
 
 var (
 	debug   = kingpin.Flag("debug", "Enable debug mode.").Bool()
-	timeout = kingpin.Flag("timeout", "Timeout waiting for ping.").Default("5s").OverrideDefaultFromEnvar("PING_TIMEOUT").Short('t').Duration()
+	timeout = kingpin.Flag("timeout", "Timeout waiting for ping.").Default("5s").Envar("PING_TIMEOUT").Short('t').Duration()
 	ip      = kingpin.Arg("ip", "IP address to ping.").Required().IP()
 	count   = kingpin.Arg("count", "Number of packets to send").Int()
 )

--- a/cmd_test.go
+++ b/cmd_test.go
@@ -349,6 +349,7 @@ func TestDefaultCmdCompletion(t *testing.T) {
 	//   - default child-cmds
 	//   - first arg hints for the final default cmd
 	assert.Equal(t, []string{"cmd2-sub1", "cmd2-sub2", "cmd2-sub2-sub1", "cmd2-sub2-sub1-arg1"}, complete(t, app, "cmd2"))
+	assert.Equal(t, []string{"cmd2-sub2-sub1-arg1"}, complete(t, app, "cmd2", "cmd2"))
 
 	// Args should be completed when all preceding cmds are explicit, and when
 	// any of them are implicit (not listed). Check this by trying all possible
@@ -372,6 +373,40 @@ func TestDefaultCmdCompletion(t *testing.T) {
 
 	// With both args of a default sub cmd, should get no completions
 	assert.Empty(t, complete(t, app, "arg1", "arg2"))
+}
+
+func TestPartialCmdCompletion(t *testing.T) {
+	app := newTestApp()
+
+	cmd1 := app.Command("cmd1", "")
+	cmd1.Arg("cmd1-arg1", "").HintOptions("cmd1-arg1-opt1", "cmd1-arg1-opt2", "cmd1-arg1-opt3").String()
+	cmd2 := app.Command("cmd2", "")
+	cmd2.Arg("cmd2-arg1", "").HintOptions("cmd2-123456", "cmd2-123789", "cmd2-456789").String()
+	cmd3 := app.Command("cmd3", "")
+	cmd3.Arg("cmd3-arg1", "").String()
+	cmd4 := app.Command("cmd4", "")
+	cmd4.Arg("cmd4-arg1", "").HintOptions("cmd4-arg1").String()
+	cmd4.Arg("cmd4-arg2", "").HintOptions("cmd4-arg2").String()
+	cmd4.Arg("cmd4-arg3", "").HintOptions("cmd4-arg3").String()
+
+
+	// partial matches
+	assert.Equal(t, []string{"cmd1-arg1-opt1", "cmd1-arg1-opt2", "cmd1-arg1-opt3"}, complete(t, app, "cmd1", "cmd1-arg1-opt"))
+	assert.Equal(t, []string{"cmd2-123456", "cmd2-123789", "cmd2-456789"}, complete(t, app, "cmd2", "cmd2-"))
+	assert.Equal(t, []string{"cmd2-123456", "cmd2-123789"}, complete(t, app, "cmd2", "cmd2-123"))
+	assert.Equal(t, []string{"cmd2-456789"}, complete(t, app, "cmd2", "cmd2-4"))
+	assert.Equal(t, []string{"cmd4-arg1"}, complete(t, app, "cmd4"))
+	assert.Equal(t, []string{"cmd4-arg1"}, complete(t, app, "cmd4", "cmd4-"))
+	assert.Equal(t, []string{"cmd4-arg2"}, complete(t, app, "cmd4", "cmd4-arg1"))
+	assert.Equal(t, []string{"cmd4-arg2"}, complete(t, app, "cmd4", "cmd4-arg1", "cmd4-arg"))
+	assert.Equal(t, []string{"cmd4-arg3"}, complete(t, app, "cmd4", "cmd4-arg1", "cmd4-arg2"))
+	assert.Equal(t, []string{"cmd4-arg3"}, complete(t, app, "cmd4", "cmd4-arg1", "cmd4-arg2", "cmd"))
+
+	// exact match
+	assert.Empty(t, complete(t, app, "cmd2", "cmd2-123456"))
+
+	// no option
+	assert.Empty(t, complete(t, app, "cmd3", "cmd3-"))
 }
 
 func TestCommandInterspersed(t *testing.T) {

--- a/flags.go
+++ b/flags.go
@@ -112,6 +112,8 @@ loop:
 
 			context.Next()
 
+			flag.isSetByUser()
+
 			fb, ok := flag.value.(boolFlag)
 			if ok && fb.IsBoolFlag() {
 				if invert {
@@ -155,6 +157,7 @@ type FlagClause struct {
 	defaultValues []string
 	placeholder   string
 	hidden        bool
+	setByUser     *bool
 
 	// allowDuplicate allows this flag to be repeated.
 	allowDuplicate bool
@@ -193,6 +196,12 @@ func (f *FlagClause) setDefault() error {
 	}
 
 	return nil
+}
+
+func (f *FlagClause) isSetByUser() {
+	if f.setByUser != nil {
+		*f.setByUser = true
+	}
 }
 
 func (f *FlagClause) needsValue() bool {
@@ -256,6 +265,15 @@ func (a *FlagClause) Enum(options ...string) (target *string) {
 		return options
 	})
 	return a.parserMixin.Enum(options...)
+}
+
+// IsSetByUser let to know if the flag was set by the user
+func (f *FlagClause) IsSetByUser(setByUser *bool) *FlagClause {
+	if setByUser != nil {
+		*setByUser = false
+	}
+	f.setByUser = setByUser
+	return f
 }
 
 // Default values for this flag. They *must* be parseable by the value of the flag.

--- a/flags_test.go
+++ b/flags_test.go
@@ -143,7 +143,7 @@ func TestEmptyShortFlagIsAnError(t *testing.T) {
 
 func TestRequiredWithEnvarMissingErrors(t *testing.T) {
 	app := newTestApp()
-	app.Flag("t", "").OverrideDefaultFromEnvar("TEST_ENVAR").Required().Int()
+	app.Flag("t", "").Envar("TEST_ENVAR").Required().Int()
 	_, err := app.Parse([]string{})
 	assert.Error(t, err)
 }

--- a/flags_test.go
+++ b/flags_test.go
@@ -366,3 +366,27 @@ func TestCombinationEnumOptions(t *testing.T) {
 	assert.Equal(t, []string{"opt5", "opt6"}, args)
 
 }
+
+func TestIsSetByUser(t *testing.T) {
+	app := newTestApp()
+	var isSet bool
+	b := app.Flag("b", "").IsSetByUser(&isSet).Bool()
+	_, err := app.Parse([]string{"--b"})
+	assert.NoError(t, err)
+	assert.True(t, *b)
+	assert.True(t, isSet)
+
+	isSet = false
+	_, err = app.Parse([]string{"--no-b"})
+	assert.NoError(t, err)
+	assert.False(t, *b)
+	assert.True(t, isSet)
+
+	isSet2 := true
+	isSet = false
+	_ = app.Flag("b2", "").IsSetByUser(&isSet2).Bool()
+	_, err = app.Parse([]string{"--b", "--unknown"})
+	assert.Error(t, err)
+	assert.True(t, isSet)
+	assert.False(t, isSet2)
+}


### PR DESCRIPTION
Part 4/5 of the upstream update https://github.com/gravitational/kingpin/pull/13

This one is short.

Conflicting commits:
- 176d5b944286afa417e8a4af31f486b0b3c08c41 
`cmd_test.go` - tests at the end of file, accepted both sides. 

- 03ad011e2ef9bee9a351250e3ebb33202de263ba
`flags.go` - upstream added `setByUser *bool`, we added `allowDuplicate bool` to `FlagClause` struct - accepted both sides.