### PR TITLE
feat: display valid enum values in help output

### DIFF
--- a/usage_renderer.go
+++ b/usage_renderer.go
@@ -325,7 +325,14 @@ func RenderManPage(w io.Writer, ctx *UsageContext) error {
 				fmt.Fprintf(w, "=%s", flag.FormatPlaceHolder())
 			}
 			fmt.Fprintln(w, `\fR`)
-			fmt.Fprintln(w, flag.Help)
+			help := flag.Help
+			// Add enum options to help text if this is an enum
+			if e, ok := flag.Value.(enumOptions); ok {
+				if options := e.EnumOptions(); len(options) > 0 {
+					help += fmt.Sprintf(" (valid: %s)", strings.Join(options, ", "))
+				}
+			}
+			fmt.Fprintln(w, help)
 		}
 	}
 
@@ -493,7 +500,14 @@ func FlagsToTwoColumns(f []*FlagModel) [][2]string {
 	haveShort := ShortFlagsPresent(f)
 	for _, flag := range f {
 		if !flag.Hidden {
-			rows = append(rows, [2]string{FormatFlag(haveShort, flag), flag.HelpWithEnvar()})
+			help := flag.HelpWithEnvar()
+			// Add enum options to help text if this is an enum
+			if e, ok := flag.Value.(enumOptions); ok {
+				if options := e.EnumOptions(); len(options) > 0 {
+					help += fmt.Sprintf(" (valid: %s)", strings.Join(options, ", "))
+				}
+			}
+			rows = append(rows, [2]string{FormatFlag(haveShort, flag), help})
 		}
 	}
 	return rows
@@ -515,7 +529,14 @@ func ArgsToTwoColumns(a []*ArgModel) [][2]string {
 		if !arg.Required {
 			s = "[" + s + "]"
 		}
-		rows = append(rows, [2]string{s, arg.HelpWithEnvar()})
+		help := arg.HelpWithEnvar()
+		// Add enum options to help text if this is an enum
+		if e, ok := arg.Value.(interface{ EnumOptions() []string }); ok {
+			if options := e.EnumOptions(); len(options) > 0 {
+				help += fmt.Sprintf(" (valid: %s)", strings.Join(options, ", "))
+			}
+		}
+		rows = append(rows, [2]string{s, help})
 	}
 	return rows
 }

--- a/usage_renderer.go
+++ b/usage_renderer.go
@@ -326,12 +326,7 @@ func RenderManPage(w io.Writer, ctx *UsageContext) error {
 			}
 			fmt.Fprintln(w, `\fR`)
 			help := flag.Help
-			// Add enum options to help text if this is an enum
-			if e, ok := flag.Value.(enumOptions); ok {
-				if options := e.EnumOptions(); len(options) > 0 {
-					help += fmt.Sprintf(" (%s: %s)", enumLabel(flag.Value), strings.Join(options, ", "))
-				}
-			}
+			help = appendEnumHelp(help, flag.Value)
 			fmt.Fprintln(w, help)
 		}
 	}
@@ -502,6 +497,23 @@ func enumLabel(v Value) string {
 	return "one of"
 }
 
+func getOptions(value Value) []string {
+	if e, ok := value.(enumOptions); ok {
+		return e.EnumOptions()
+	}
+	return nil
+}
+
+// appendEnumHelp appends "(one of: a, b)" or "(any of: a, b)" to help if v
+// implements enumOptions and has at least one option. Returns help unchanged
+// when v is not an enum or has no options.
+func appendEnumHelp(help string, v Value) string {
+	if options := getOptions(v); len(options) > 0 {
+		return help + fmt.Sprintf(" (%s: %s)", enumLabel(v), strings.Join(options, ", "))
+	}
+	return help
+}
+
 // FlagsToTwoColumns converts a slice of flags into two-column row data
 // suitable for FormatTwoColumns. Hidden flags are excluded.
 func FlagsToTwoColumns(f []*FlagModel) [][2]string {
@@ -511,11 +523,7 @@ func FlagsToTwoColumns(f []*FlagModel) [][2]string {
 		if !flag.Hidden {
 			help := flag.HelpWithEnvar()
 			// Add enum options to help text if this is an enum
-			if e, ok := flag.Value.(enumOptions); ok {
-				if options := e.EnumOptions(); len(options) > 0 {
-					help += fmt.Sprintf(" (%s: %s)", enumLabel(flag.Value), strings.Join(options, ", "))
-				}
-			}
+			help = appendEnumHelp(help, flag.Value)
 			rows = append(rows, [2]string{FormatFlag(haveShort, flag), help})
 		}
 	}
@@ -538,13 +546,7 @@ func ArgsToTwoColumns(a []*ArgModel) [][2]string {
 		if !arg.Required {
 			s = "[" + s + "]"
 		}
-		help := arg.HelpWithEnvar()
-		// Add enum options to help text if this is an enum
-		if e, ok := arg.Value.(enumOptions); ok {
-			if options := e.EnumOptions(); len(options) > 0 {
-				help += fmt.Sprintf(" (%s: %s)", enumLabel(arg.Value), strings.Join(options, ", "))
-			}
-		}
+		help := appendEnumHelp(arg.HelpWithEnvar(), arg.Value)
 		rows = append(rows, [2]string{s, help})
 	}
 	return rows

--- a/usage_renderer.go
+++ b/usage_renderer.go
@@ -329,7 +329,7 @@ func RenderManPage(w io.Writer, ctx *UsageContext) error {
 			// Add enum options to help text if this is an enum
 			if e, ok := flag.Value.(enumOptions); ok {
 				if options := e.EnumOptions(); len(options) > 0 {
-					help += fmt.Sprintf(" (valid: %s)", strings.Join(options, ", "))
+					help += fmt.Sprintf(" (%s: %s)", enumLabel(flag.Value), strings.Join(options, ", "))
 				}
 			}
 			fmt.Fprintln(w, help)
@@ -493,6 +493,15 @@ func RenderFishCompletion(w io.Writer, ctx *UsageContext) error {
 	return nil
 }
 
+// enumLabel returns "one of" for a single-value enum and "any of" for a
+// multi-value (cumulative) enum.
+func enumLabel(v Value) string {
+	if r, ok := v.(repeatableFlag); ok && r.IsCumulative() {
+		return "any of"
+	}
+	return "one of"
+}
+
 // FlagsToTwoColumns converts a slice of flags into two-column row data
 // suitable for FormatTwoColumns. Hidden flags are excluded.
 func FlagsToTwoColumns(f []*FlagModel) [][2]string {
@@ -504,7 +513,7 @@ func FlagsToTwoColumns(f []*FlagModel) [][2]string {
 			// Add enum options to help text if this is an enum
 			if e, ok := flag.Value.(enumOptions); ok {
 				if options := e.EnumOptions(); len(options) > 0 {
-					help += fmt.Sprintf(" (valid: %s)", strings.Join(options, ", "))
+					help += fmt.Sprintf(" (%s: %s)", enumLabel(flag.Value), strings.Join(options, ", "))
 				}
 			}
 			rows = append(rows, [2]string{FormatFlag(haveShort, flag), help})
@@ -531,9 +540,9 @@ func ArgsToTwoColumns(a []*ArgModel) [][2]string {
 		}
 		help := arg.HelpWithEnvar()
 		// Add enum options to help text if this is an enum
-		if e, ok := arg.Value.(interface{ EnumOptions() []string }); ok {
+		if e, ok := arg.Value.(enumOptions); ok {
 			if options := e.EnumOptions(); len(options) > 0 {
-				help += fmt.Sprintf(" (valid: %s)", strings.Join(options, ", "))
+				help += fmt.Sprintf(" (%s: %s)", enumLabel(arg.Value), strings.Join(options, ", "))
 			}
 		}
 		rows = append(rows, [2]string{s, help})

--- a/usage_template.go
+++ b/usage_template.go
@@ -47,7 +47,7 @@ func templateRenderFunc(a *Application, context *ParseContext, indent int, tmpl 
 					// Add enum options to help text if this is an enum
 					if e, ok := flag.Value.(enumOptions); ok {
 						if options := e.EnumOptions(); len(options) > 0 {
-							help += fmt.Sprintf(" (valid: %s)", strings.Join(options, ", "))
+							help += fmt.Sprintf(" (%s: %s)", enumLabel(flag.Value), strings.Join(options, ", "))
 						}
 					}
 					rows = append(rows, [2]string{FormatFlagCompact(haveShort, flag), help})

--- a/usage_template.go
+++ b/usage_template.go
@@ -2,6 +2,7 @@ package kingpin
 
 import (
 	"bytes"
+	"fmt"
 	"strings"
 	"text/template"
 )
@@ -42,7 +43,14 @@ func templateRenderFunc(a *Application, context *ParseContext, indent int, tmpl 
 			haveShort := ShortFlagsPresent(f)
 			for _, flag := range f {
 				if !flag.Hidden {
-					rows = append(rows, [2]string{FormatFlagCompact(haveShort, flag), flag.Help})
+					help := flag.Help
+					// Add enum options to help text if this is an enum
+					if e, ok := flag.Value.(enumOptions); ok {
+						if options := e.EnumOptions(); len(options) > 0 {
+							help += fmt.Sprintf(" (valid: %s)", strings.Join(options, ", "))
+						}
+					}
+					rows = append(rows, [2]string{FormatFlagCompact(haveShort, flag), help})
 				}
 			}
 			return rows
@@ -82,6 +90,12 @@ func templateRenderFunc(a *Application, context *ParseContext, indent int, tmpl 
 		"IsCumulative": func(value Value) bool {
 			r, ok := value.(repeatableFlag)
 			return ok && r.IsCumulative()
+		},
+		"EnumOptions": func(value Value) []string {
+			if e, ok := value.(enumOptions); ok {
+				return e.EnumOptions()
+			}
+			return nil
 		},
 		"Char": func(c rune) string {
 			return string(c)

--- a/usage_template.go
+++ b/usage_template.go
@@ -2,7 +2,6 @@ package kingpin
 
 import (
 	"bytes"
-	"fmt"
 	"strings"
 	"text/template"
 )
@@ -43,14 +42,7 @@ func templateRenderFunc(a *Application, context *ParseContext, indent int, tmpl 
 			haveShort := ShortFlagsPresent(f)
 			for _, flag := range f {
 				if !flag.Hidden {
-					help := flag.Help
-					// Add enum options to help text if this is an enum
-					if e, ok := flag.Value.(enumOptions); ok {
-						if options := e.EnumOptions(); len(options) > 0 {
-							help += fmt.Sprintf(" (%s: %s)", enumLabel(flag.Value), strings.Join(options, ", "))
-						}
-					}
-					rows = append(rows, [2]string{FormatFlagCompact(haveShort, flag), help})
+					rows = append(rows, [2]string{FormatFlagCompact(haveShort, flag), appendEnumHelp(flag.Help, flag.Value)})
 				}
 			}
 			return rows
@@ -92,10 +84,7 @@ func templateRenderFunc(a *Application, context *ParseContext, indent int, tmpl 
 			return ok && r.IsCumulative()
 		},
 		"EnumOptions": func(value Value) []string {
-			if e, ok := value.(enumOptions); ok {
-				return e.EnumOptions()
-			}
-			return nil
+			return getOptions(value)
 		},
 		"Char": func(c rune) string {
 			return string(c)

--- a/usage_test.go
+++ b/usage_test.go
@@ -417,8 +417,8 @@ func TestEnumFlagRendering(t *testing.T) {
 			require.NoError(t, err)
 			usage := buf.String()
 
-			assert.Contains(t, usage, "json, yaml, xml")
-			assert.Contains(t, usage, "debug, info, warn, error")
+			assert.Contains(t, usage, "one of: json, yaml, xml")
+			assert.Contains(t, usage, "one of: debug, info, warn, error")
 		})
 	}
 }
@@ -473,8 +473,8 @@ func TestEnumArgRendering(t *testing.T) {
 			require.NoError(t, err)
 			usage := buf.String()
 
-			assert.Contains(t, usage, "create, read, update, delete")
-			assert.Contains(t, usage, "json, yaml, xml")
+			assert.Contains(t, usage, "one of: create, read, update, delete")
+			assert.Contains(t, usage, "one of: json, yaml, xml")
 		})
 	}
 }
@@ -542,8 +542,8 @@ func TestEnumWithCommand(t *testing.T) {
 	require.NoError(t, err)
 	usage := buf.String()
 
-	assert.Contains(t, usage, "dev, staging, prod")
-	assert.Contains(t, usage, "us-east-1, us-west-2, eu-west-1")
+	assert.Contains(t, usage, "one of: dev, staging, prod")
+	assert.Contains(t, usage, "one of: us-east-1, us-west-2, eu-west-1")
 }
 
 func TestEnumOptionsTemplateFunction(t *testing.T) {
@@ -573,9 +573,9 @@ func TestEnumWithEnvar(t *testing.T) {
 	usage := buf.String()
 
 	assert.Contains(t, usage, "$FORMAT")
-	assert.Contains(t, usage, "json, yaml, xml")
+	assert.Contains(t, usage, "one of: json, yaml, xml")
 	assert.Contains(t, usage, "$LEVEL")
-	assert.Contains(t, usage, "debug, info, warn")
+	assert.Contains(t, usage, "one of: debug, info, warn")
 }
 
 func TestFlagsToTwoColumnsWithEnums(t *testing.T) {
@@ -597,11 +597,11 @@ func TestFlagsToTwoColumnsWithEnums(t *testing.T) {
 
 	// First row should have enum values
 	assert.Contains(t, rows[0][1], "Output format")
-	assert.Contains(t, rows[0][1], "(valid: json, yaml, xml)")
+	assert.Contains(t, rows[0][1], "(one of: json, yaml, xml)")
 
 	// Second row should not have enum values
 	assert.Equal(t, "Verbose output", rows[1][1])
-	assert.NotContains(t, rows[1][1], "(valid:")
+	assert.NotContains(t, rows[1][1], "(one of:")
 }
 
 func TestArgsToTwoColumnsWithEnums(t *testing.T) {
@@ -625,9 +625,9 @@ func TestArgsToTwoColumnsWithEnums(t *testing.T) {
 
 	// First row should have enum values
 	assert.Contains(t, rows[0][1], "Action to perform")
-	assert.Contains(t, rows[0][1], "(valid: create, delete, update)")
+	assert.Contains(t, rows[0][1], "(one of: create, delete, update)")
 
 	// Second row should not have enum values
 	assert.Equal(t, "File to process", rows[1][1])
-	assert.NotContains(t, rows[1][1], "(valid:")
+	assert.NotContains(t, rows[1][1], "(one of:")
 }

--- a/usage_test.go
+++ b/usage_test.go
@@ -354,3 +354,280 @@ func TestRenderersMatchTemplates(t *testing.T) {
 		}
 	}
 }
+
+func TestEnumFlagRendering(t *testing.T) {
+	tests := []struct {
+		name     string
+		renderer UsageRenderer
+		template string
+	}{
+		{
+			name:     "default template",
+			template: DefaultUsageTemplate,
+		},
+		{
+			name:     "default renderer",
+			renderer: RenderDefault,
+		},
+		{
+			name:     "compact template",
+			template: CompactUsageTemplate,
+		},
+		{
+			name:     "compact renderer",
+			renderer: RenderCompact,
+		},
+		{
+			name:     "separate optional flags template",
+			template: SeparateOptionalFlagsUsageTemplate,
+		},
+		{
+			name:     "separate optional flags renderer",
+			renderer: RenderSeparateOptionalFlags,
+		},
+		{
+			name:     "long help template",
+			template: LongHelpTemplate,
+		},
+		{
+			name:     "long help renderer",
+			renderer: RenderLongHelp,
+		},
+		{
+			name:     "man page renderer",
+			renderer: RenderManPage,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			var buf bytes.Buffer
+			a := New("test", "Test enum flags").Writer(&buf).Terminate(nil)
+			a.Flag("format", "Output format").Default("json").Enum("json", "yaml", "xml")
+			a.Flag("level", "Log level").Enum("debug", "info", "warn", "error")
+
+			if tt.template != "" {
+				a.UsageTemplate(tt.template)
+			}
+			if tt.renderer != nil {
+				a.UsageRenderer(tt.renderer)
+			}
+
+			_, err := a.Parse([]string{"--help"})
+			require.NoError(t, err)
+			usage := buf.String()
+
+			assert.Contains(t, usage, "json, yaml, xml")
+			assert.Contains(t, usage, "debug, info, warn, error")
+		})
+	}
+}
+
+func TestEnumArgRendering(t *testing.T) {
+	tests := []struct {
+		name     string
+		renderer UsageRenderer
+		template string
+	}{
+		{
+			name:     "default template",
+			template: DefaultUsageTemplate,
+		},
+		{
+			name:     "default renderer",
+			renderer: RenderDefault,
+		},
+		{
+			name:     "compact template",
+			template: CompactUsageTemplate,
+		},
+		{
+			name:     "compact renderer",
+			renderer: RenderCompact,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			var buf bytes.Buffer
+			a := New("test", "Test enum args").Writer(&buf).Terminate(nil)
+			a.Arg("action", "Action to perform").Required().Enum("create", "read", "update", "delete")
+			a.Arg("format", "Output format").Enum("json", "yaml", "xml")
+
+			if tt.template != "" {
+				a.UsageTemplate(tt.template)
+			}
+			if tt.renderer != nil {
+				a.UsageRenderer(tt.renderer)
+			}
+
+			// Parse with a valid action to avoid required arg error
+			ctx, err := a.ParseContext([]string{"create", "--help"})
+			require.NoError(t, err)
+
+			if tt.template != "" {
+				err = a.UsageForContextWithTemplate(ctx, 2, tt.template)
+			} else {
+				err = a.usageForContextWithUsageRenderer(ctx, 2, tt.renderer)
+			}
+			require.NoError(t, err)
+			usage := buf.String()
+
+			assert.Contains(t, usage, "create, read, update, delete")
+			assert.Contains(t, usage, "json, yaml, xml")
+		})
+	}
+}
+
+func TestEnumMultiValueRendering(t *testing.T) {
+	tests := []struct {
+		name     string
+		renderer UsageRenderer
+		template string
+	}{
+		{
+			name:     "default template",
+			template: DefaultUsageTemplate,
+		},
+		{
+			name:     "default renderer",
+			renderer: RenderDefault,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			var buf bytes.Buffer
+			a := New("test", "Test multi-value enums").Writer(&buf).Terminate(nil)
+			a.Flag("feature", "Enable features (repeatable)").Enums("auth", "logging", "metrics", "tracing")
+			a.Arg("tags", "Tags to apply (repeatable)").Enums("dev", "prod", "staging", "test")
+
+			if tt.template != "" {
+				a.UsageTemplate(tt.template)
+			}
+			if tt.renderer != nil {
+				a.UsageRenderer(tt.renderer)
+			}
+
+			_, err := a.Parse([]string{"--help"})
+			require.NoError(t, err)
+			usage := buf.String()
+
+			// Enum values may wrap across lines in the output
+			assert.Contains(t, usage, "auth")
+			assert.Contains(t, usage, "logging")
+			assert.Contains(t, usage, "metrics")
+			assert.Contains(t, usage, "tracing")
+			assert.Contains(t, usage, "dev")
+			assert.Contains(t, usage, "prod")
+			assert.Contains(t, usage, "staging")
+			assert.Contains(t, usage, "test")
+		})
+	}
+}
+
+func TestEnumWithCommand(t *testing.T) {
+	var buf bytes.Buffer
+	a := New("test", "Test with commands").Writer(&buf).Terminate(nil)
+
+	cmd := a.Command("deploy", "Deploy application")
+	cmd.Flag("env", "Environment").Default("dev").Enum("dev", "staging", "prod")
+	cmd.Arg("region", "AWS region").Required().Enum("us-east-1", "us-west-2", "eu-west-1")
+
+	// Parse with valid region to avoid required arg error
+	ctx, err := a.ParseContext([]string{"deploy", "us-east-1", "--help"})
+	require.NoError(t, err)
+
+	err = a.UsageForContext(ctx)
+	require.NoError(t, err)
+	usage := buf.String()
+
+	assert.Contains(t, usage, "dev, staging, prod")
+	assert.Contains(t, usage, "us-east-1, us-west-2, eu-west-1")
+}
+
+func TestEnumOptionsTemplateFunction(t *testing.T) {
+	var buf bytes.Buffer
+	a := New("test", "Test").Writer(&buf).Terminate(nil)
+	a.Flag("format", "Output format").Enum("json", "yaml", "xml")
+
+	// Use custom template that uses EnumOptions function
+	tmpl := `{{ range .Context.Flags }}{{ if EnumOptions .Value }}Options: {{ range EnumOptions .Value }}{{ . }} {{ end }}{{ end }}{{ end }}`
+	a.UsageTemplate(tmpl)
+
+	_, err := a.Parse([]string{"--help"})
+	require.NoError(t, err)
+	usage := buf.String()
+
+	assert.Contains(t, usage, "Options: json yaml xml")
+}
+
+func TestEnumWithEnvar(t *testing.T) {
+	var buf bytes.Buffer
+	a := New("test", "Test").Writer(&buf).Terminate(nil)
+	a.Flag("format", "Output format").Envar("FORMAT").Enum("json", "yaml", "xml")
+	a.Arg("level", "Log level").Envar("LEVEL").Enum("debug", "info", "warn")
+
+	_, err := a.Parse([]string{"--help"})
+	require.NoError(t, err)
+	usage := buf.String()
+
+	assert.Contains(t, usage, "$FORMAT")
+	assert.Contains(t, usage, "json, yaml, xml")
+	assert.Contains(t, usage, "$LEVEL")
+	assert.Contains(t, usage, "debug, info, warn")
+}
+
+func TestFlagsToTwoColumnsWithEnums(t *testing.T) {
+	flags := []*FlagModel{
+		{
+			Name:  "format",
+			Help:  "Output format",
+			Value: newEnumFlag(new(string), "json", "yaml", "xml"),
+		},
+		{
+			Name:  "verbose",
+			Help:  "Verbose output",
+			Value: newBoolValue(new(bool)),
+		},
+	}
+
+	rows := FlagsToTwoColumns(flags)
+	require.Len(t, rows, 2)
+
+	// First row should have enum values
+	assert.Contains(t, rows[0][1], "Output format")
+	assert.Contains(t, rows[0][1], "(valid: json, yaml, xml)")
+
+	// Second row should not have enum values
+	assert.Equal(t, "Verbose output", rows[1][1])
+	assert.NotContains(t, rows[1][1], "(valid:")
+}
+
+func TestArgsToTwoColumnsWithEnums(t *testing.T) {
+	args := []*ArgModel{
+		{
+			Name:     "action",
+			Help:     "Action to perform",
+			Required: true,
+			Value:    newEnumFlag(new(string), "create", "delete", "update"),
+		},
+		{
+			Name:     "file",
+			Help:     "File to process",
+			Required: false,
+			Value:    newStringValue(new(string)),
+		},
+	}
+
+	rows := ArgsToTwoColumns(args)
+	require.Len(t, rows, 2)
+
+	// First row should have enum values
+	assert.Contains(t, rows[0][1], "Action to perform")
+	assert.Contains(t, rows[0][1], "(valid: create, delete, update)")
+
+	// Second row should not have enum values
+	assert.Equal(t, "File to process", rows[1][1])
+	assert.NotContains(t, rows[1][1], "(valid:")
+}

--- a/usage_test.go
+++ b/usage_test.go
@@ -631,3 +631,43 @@ func TestArgsToTwoColumnsWithEnums(t *testing.T) {
 	assert.Equal(t, "File to process", rows[1][1])
 	assert.NotContains(t, rows[1][1], "(one of:")
 }
+
+func TestAppendEnumHelp(t *testing.T) {
+	tests := []struct {
+		name string
+		help string
+		v    Value
+		want string
+	}{
+		{
+			name: "single enum appends one of",
+			help: "Output format",
+			v:    newEnumFlag(new(string), "json", "yaml", "xml"),
+			want: "Output format (one of: json, yaml, xml)",
+		},
+		{
+			name: "multi enum appends any of",
+			help: "Log levels",
+			v:    newEnumsFlag(new([]string), "debug", "info", "warn"),
+			want: "Log levels (any of: debug, info, warn)",
+		},
+		{
+			name: "non-enum value is unchanged",
+			help: "Verbose output",
+			v:    newBoolValue(new(bool)),
+			want: "Verbose output",
+		},
+		{
+			name: "empty help string",
+			help: "",
+			v:    newEnumFlag(new(string), "a", "b"),
+			want: " (one of: a, b)",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			assert.Equal(t, tt.want, appendEnumHelp(tt.help, tt.v))
+		})
+	}
+}

--- a/values.go
+++ b/values.go
@@ -58,6 +58,11 @@ type repeatableFlag interface {
 	IsCumulative() bool
 }
 
+// Optional interface for enum values that have a set of valid options.
+type enumOptions interface {
+	EnumOptions() []string
+}
+
 // Text is the interface to the dynamic value stored in a flag.
 // (The default value is represented as a string.)
 type Text interface {
@@ -87,9 +92,10 @@ type accumulator struct {
 // Use reflection to accumulate values into a slice.
 //
 // target := []string{}
-// newAccumulator(&target, func (value interface{}) Value {
-//   return newStringValue(value.(*string))
-// })
+//
+//	newAccumulator(&target, func (value interface{}) Value {
+//	  return newStringValue(value.(*string))
+//	})
 func newAccumulator(slice interface{}, element func(value interface{}) Value) *accumulator {
 	typ := reflect.TypeOf(slice)
 	if typ.Kind() != reflect.Ptr || typ.Elem().Kind() != reflect.Slice {
@@ -386,6 +392,10 @@ func (e *enumValue) Get() interface{} {
 	return (string)(*e.value)
 }
 
+func (e *enumValue) EnumOptions() []string {
+	return e.options
+}
+
 // -- []string Enum Value
 type enumsValue struct {
 	value   *[]string
@@ -419,6 +429,10 @@ func (s *enumsValue) String() string {
 
 func (s *enumsValue) IsCumulative() bool {
 	return true
+}
+
+func (e *enumsValue) EnumOptions() []string {
+	return e.options
 }
 
 // -- units.Base2Bytes Value


### PR DESCRIPTION
Add enum value rendering to all usage output formats (default, compact, long help, man page) for both flags and arguments. When a flag or arg uses Enum() or Enums(), the valid options are now automatically shown in the help text as "(any|one of: option1, option2, ...)".

Example output:
  --format=json  Output format (one of: json, yaml, xml)
  <action>       Action to perform (any of: create, read, update, delete)